### PR TITLE
[0.0.6] Update node versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [16.x, 15.x, 14.x, 12.x, 10.x]
+                node-version: [19.x, 18.x, 16.x, 14.x]
                 os: [ubuntu-latest, macos-latest]
 
         runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0x/fast-abi",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "",
     "main": "lib/index.js",
     "author": "Jacob Evans <jacob@dekz.net>",


### PR DESCRIPTION
Bumps version to 0.0.6 and updates build to [current node versions](https://github.com/nodejs/release#release-schedule)