### PR TITLE
Fix code so it works with Neon 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,31 +3,28 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2f58b0bb10c380af2b26e57212856b8c9a59e0925b4c20f4a174a49734eaf7"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitvec"
-version = "0.20.2"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f682656975d3a682daff957be4ddeb65d6ad656737cd821f2d00685ae466af1"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
  "radium",
@@ -53,9 +50,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.0.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -65,21 +62,24 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
-
-[[package]]
-name = "cc"
-version = "1.0.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crunchy"
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "14.0.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52991643379afc90bfe2df3c64d53983e59c35a82ba6e75c997cfc2880d8524"
+checksum = "a01317735d563b3bad2d5f90d2e1799f414165408251abb762510f40e790e69a"
 dependencies = [
  "anyhow",
  "ethereum-types",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
 dependencies = [
  "crunchy",
  "fixed-hash",
@@ -141,13 +141,12 @@ dependencies = [
 
 [[package]]
 name = "fast-abi"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethabi",
  "hex",
  "neon",
- "neon-build",
 ]
 
 [[package]]
@@ -170,9 +169,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -180,14 +179,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hex"
@@ -197,9 +202,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "impl-codec"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -215,36 +220,70 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.7"
+name = "impl-trait-for-tuples"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "keccak"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "neon"
@@ -253,6 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28e15415261d880aed48122e917a45e87bb82cf0260bb6db48bbab44b7464373"
 dependencies = [
  "neon-build",
+ "neon-macros",
  "neon-runtime",
  "semver",
  "smallvec",
@@ -263,8 +303,16 @@ name = "neon-build"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bac98a702e71804af3dacfde41edde4a16076a7bbe889ae61e56e18c5b1c811"
+
+[[package]]
+name = "neon-macros"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7288eac8b54af7913c60e0eb0e2a7683020dffa342ab3fd15e28f035ba897cf"
 dependencies = [
- "neon-sys",
+ "quote",
+ "syn",
+ "syn-mid",
 ]
 
 [[package]]
@@ -274,19 +322,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676720fa8bb32c64c3d9f49c47a47289239ec46b4bdb66d0913cc512cb0daca"
 dependencies = [
  "cfg-if",
- "neon-sys",
+ "libloading",
  "smallvec",
 ]
 
 [[package]]
-name = "neon-sys"
-version = "0.10.1"
+name = "nom8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ebc923308ac557184455b4aaa749470554cbac70eb4daa8b18cdc16bef7df6"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
 dependencies = [
- "cc",
- "regex",
+ "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -296,27 +349,41 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.1.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f518afaa5a47d0d6386229b0a6e01e86427291d643aa4cabb4992219f504f8"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
  "serde",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.10"
+name = "parity-scale-codec-derive"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primitive-types"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
+checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -326,19 +393,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.26"
+name = "proc-macro-crate"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
 dependencies = [
- "unicode-xid",
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -351,9 +428,9 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -362,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -372,35 +449,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "regex"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
-
-[[package]]
 name = "rlp"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -414,9 +474,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "semver"
@@ -435,18 +495,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -455,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -478,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "static_assertions"
@@ -490,13 +550,24 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -507,18 +578,18 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -535,16 +606,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.13.0"
+name = "toml_datetime"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_edit"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "toml_datetime",
+]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uint"
-version = "0.9.0"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -553,22 +641,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.1"
+name = "unicode-ident"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
-name = "fast-abi"
-version = "0.0.1"
 authors = ["Jacob Evans <jacob@dekz.net>"]
-license = "MIT"
-build = "build.rs"
 edition = "2018"
 exclude = ["artifacts.json", "index.node"]
+license = "MIT"
+name = "fast-abi"
+version = "0.1.0"
 
 [lib]
 crate-type = ["cdylib"]
 
-
-[build-dependencies]
-neon-build = "0.10.1"
-
 [dependencies]
-neon = "0.10.1"
-anyhow = "1.0.40"
-hex = "0.4.2"
+anyhow = "1.0.69"
 ethabi = "14.0"
+hex = "0.4.2"
+
+[dependencies.neon]
+default-features = false
+features = ["napi-6"]
+version = "0.10.1"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,0 @@
-extern crate neon_build;
-
-fn main() {
-    neon_build::setup(); // must be called in build.rs
-
-    // add project-specific build logic here...
-}

--- a/src/fast_abi.ts
+++ b/src/fast_abi.ts
@@ -1,7 +1,7 @@
 import { DataItem, MethodAbi } from 'ethereum-types';
 import { BigNumber } from 'bignumber.js';
 
-const { Coder } = require('../bin');
+const { coderNew, coderEncodeInput, coderDecodeInput, coderDecodeOutput } = require('../bin');
 
 interface Opts {
     BigNumber: any;
@@ -15,29 +15,29 @@ export class FastABI {
     constructor(abi: MethodAbi[], opts?: Opts) {
         this._opts = { BigNumber: BigNumber, ...opts } || { BigNumber: BigNumber };
         this._abi = abi;
-        this._coder = new Coder(JSON.stringify(abi));
+        this._coder = coderNew(JSON.stringify(abi));
     }
 
     public encodeInput(fnName: string, values: any[]): string {
         const found = this._abi.filter((a) => a.name === fnName)[0];
         const args = this._serializeArgsOut(values, found.inputs);
         try {
-            const encoded = this._coder.encodeInput(fnName, args);
+            const encoded = coderEncodeInput.call(this._coder, fnName, args);
             return `0x${encoded}`;
         } catch (e) {
-            throw new Error(`${e.message}.\nvalues=${JSON.stringify(values)}\nargs=${JSON.stringify(args)}`);
+            throw new Error(`${(e as Error).message}.\nvalues=${JSON.stringify(values)}\nargs=${JSON.stringify(args)}`);
         }
     }
 
     public decodeInput(fnName: string, output: string): any {
         const found = this._abi.filter((a) => a.name === fnName)[0];
-        const decoded = this._coder.decodeInput(fnName, output);
+        const decoded = coderDecodeInput.call(this._coder, fnName, output);
         return this._deserializeResultsIn(found.inputs, decoded);
     }
 
     public decodeOutput(fnName: string, output: string): any {
         const found = this._abi.filter((a) => a.name === fnName)[0];
-        const decoded = this._coder.decodeOutput(fnName, output);
+        const decoded = coderDecodeOutput.call(this._coder, fnName, output);
         return this._deserializeResultsIn(found.outputs, decoded);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,24 @@ use ethabi::{
 };
 use neon::{prelude::*, result::Throw};
 use result_ext::ResultExt;
+use std::str;
 
+/**
+ * Wraps ethabi `LenientTokenizer` functions so that they can
+ * be used via JavaScript.
+ * 
+ * This example was very helpful:
+ * https://github.com/neon-bindings/examples/tree/223ba9b4870fefc18ad18a7a474f49acbe8b77f6/examples/async-sqlite
+ */
 pub struct Coder(Contract);
 
+impl Finalize for Coder {}
+
+// Internal Implementation
 impl Coder {
     pub fn new(abi_json: &str) -> anyhow::Result<Self> {
-        Ok(Contract::load(abi_json.as_bytes()).map(Self)?)
+        let contract = Contract::load(abi_json.as_bytes()).map(Self)?;
+        Ok(contract)
     }
 
     pub fn argument_types(&self, function: &str) -> anyhow::Result<Vec<ParamType>> {
@@ -43,65 +55,69 @@ impl Coder {
     }
 }
 
-declare_types! {
-    pub class JsCoder for Coder {
-        init(mut cx) {
-            Coder::new(cx.argument::<JsString>(0)?.value().as_ref())
-            .or_throw(&mut cx)
-        }
+// Implementation exposed to TS
+impl Coder {
+    // Create a new instance of `Database` and place it inside a `JsBox`
+    // JavaScript can hold a reference to a `JsBox`, but the contents are opaque
+    fn js_new(mut cx: FunctionContext) -> JsResult<JsBox<Coder>> {
+        let abi = cx.argument::<JsString>(0)?.value(&mut cx);
+        let coder = Coder::new(abi.as_ref()).unwrap();
 
-        method encodeInput(mut cx) {
-            let this = cx.this();
-            let function = cx.argument::<JsString>(0)?.value();
-            let arguments = cx.argument::<JsArray>(1)?.to_vec(&mut cx)?;
+        Ok(cx.boxed(coder))
+    }
 
-            // Fetch argument types
-            let kinds = cx.borrow(&this, |coder| coder.argument_types(&function))
-            .or_throw(&mut cx)?;
+    fn js_encode_input(mut cx: FunctionContext) -> JsResult<JsString> {
+        let function = cx.argument::<JsString>(0)?.value(&mut cx);
+        let arguments = cx.argument::<JsArray>(1)?.to_vec(&mut cx)?;
 
-            // Cast JsValues into correct token types
-            let tokens = kinds.iter().zip(arguments.iter())
+        let coder = cx.this().downcast_or_throw::<JsBox<Coder>, _>(&mut cx)?;
+
+        let kinds = coder.argument_types(&function).or_throw(&mut cx)?;
+
+        // Cast JsValues into correct token types
+        let tokens = kinds
+            .iter()
+            .zip(arguments.iter())
             .map(|(kind, value)| tokenize(&mut cx, kind, value))
-            .collect::<Result<Vec<_>,_>>()
+            .collect::<Result<Vec<_>, _>>()
             .or_throw(&mut cx)?;
 
-            // Encode tokenized arguments
-            cx.borrow(&this, |coder| coder.encode_input(&function, &tokens))
-            .or_throw(&mut cx)
-            .map(|s| cx.string(s).upcast())
-        }
+        let encoded_input = coder.encode_input(&function, &tokens).unwrap();
+        Ok(cx.string(encoded_input))
+    }
 
-        method decodeInput(mut cx) {
-            let this = cx.this();
-            let function = cx.argument::<JsString>(0)?.value();
-            let data = cx.argument::<JsString>(1)?.value();
+    fn js_decode_input(mut cx: FunctionContext) -> JsResult<JsArray> {
+        let function = cx.argument::<JsString>(0)?.value(&mut cx);
+        let data = cx.argument::<JsString>(1)?.value(&mut cx);
 
-            // Decode calldata to tokens
-            let tokens = cx.borrow(&this, |coder| coder.decode_input(&function, &data))
-            .or_throw(&mut cx)?;
-            tokens_to_js(&mut cx, &tokens)
-        }
+        let coder = cx.this().downcast_or_throw::<JsBox<Coder>, _>(&mut cx)?;
 
-        method decodeOutput(mut cx) {
-            let this = cx.this();
-            let function = cx.argument::<JsString>(0)?.value();
-            let data = cx.argument::<JsString>(1)?.value();
+        // Decode calldata to tokens
+        let tokens = coder.decode_input(&function, &data).or_throw(&mut cx)?;
 
-            // Decode calldata to tokens
-            let tokens = cx.borrow(&this, |coder| coder.decode_output(&function, &data))
-            .or_throw(&mut cx)?;
-            tokens_to_js(&mut cx, &tokens)
-        }
+        tokens_to_js(&mut cx, &tokens)
+    }
+
+    fn js_decode_output(mut cx: FunctionContext) -> JsResult<JsArray> {
+        let function = cx.argument::<JsString>(0)?.value(&mut cx);
+        let data = cx.argument::<JsString>(1)?.value(&mut cx);
+
+        let coder = cx.this().downcast_or_throw::<JsBox<Coder>, _>(&mut cx)?;
+
+        let tokens = coder.decode_output(&function, &data).or_throw(&mut cx)?;
+
+        tokens_to_js(&mut cx, &tokens)
     }
 }
 
-fn tokens_to_js<'cx, C: Context<'cx>>(cx: &mut C, tokens: &[Token]) -> JsResult<'cx, JsValue> {
+fn tokens_to_js<'a, C: Context<'a>>(cx: &mut C, tokens: &[Token]) -> JsResult<'a, JsArray> {
+    // See https://neon-bindings.com/docs/arrays#converting-a-rust-vector-to-an-array
     let result = JsArray::new(cx, tokens.len() as u32);
     for (i, token) in tokens.iter().enumerate() {
         let value = tokenize_out(token, cx)?;
         result.set(cx, i as u32, value)?;
     }
-    Ok(result.upcast())
+    Ok(result)
 }
 
 fn tokenize_out<'cx, C: Context<'cx>>(token: &Token, cx: &mut C) -> JsResult<'cx, JsValue> {
@@ -143,7 +159,7 @@ fn tokenize_address<'cx, C: Context<'cx>>(
     cx: &mut C,
     value: &Handle<JsValue>,
 ) -> Result<[u8; 20], Throw> {
-    let arg = value.downcast_or_throw::<JsString, _>(cx)?.value();
+    let arg = value.downcast_or_throw::<JsString, _>(cx)?.value(cx);
     LenientTokenizer::tokenize_address(remove_hex_prefix(&arg)).or_throw(cx)
 }
 
@@ -151,12 +167,12 @@ fn tokenize_string<'cx, C: Context<'cx>>(
     cx: &mut C,
     value: &Handle<JsValue>,
 ) -> Result<String, Throw> {
-    let arg = value.downcast_or_throw::<JsString, _>(cx)?.value();
+    let arg = value.downcast_or_throw::<JsString, _>(cx)?.value(cx);
     LenientTokenizer::tokenize_string(&arg).or_throw(cx)
 }
 
 fn tokenize_bool<'cx, C: Context<'cx>>(cx: &mut C, value: &Handle<JsValue>) -> Result<bool, Throw> {
-    let arg = value.downcast_or_throw::<JsBoolean, _>(cx)?.value();
+    let arg = value.downcast_or_throw::<JsBoolean, _>(cx)?.value(cx);
     Ok(arg)
 }
 
@@ -164,7 +180,7 @@ fn tokenize_bytes<'cx, C: Context<'cx>>(
     cx: &mut C,
     value: &Handle<JsValue>,
 ) -> Result<Vec<u8>, Throw> {
-    let arg = value.downcast_or_throw::<JsString, _>(cx)?.value();
+    let arg = value.downcast_or_throw::<JsString, _>(cx)?.value(cx);
     LenientTokenizer::tokenize_bytes(remove_hex_prefix(&arg)).or_throw(cx)
 }
 
@@ -173,7 +189,7 @@ fn tokenize_fixed_bytes<'cx, C: Context<'cx>>(
     value: &Handle<JsValue>,
     len: usize,
 ) -> Result<Vec<u8>, Throw> {
-    let arg = value.downcast_or_throw::<JsString, _>(cx)?.value();
+    let arg = value.downcast_or_throw::<JsString, _>(cx)?.value(cx);
     LenientTokenizer::tokenize_fixed_bytes(remove_hex_prefix(&arg), len).or_throw(cx)
 }
 
@@ -181,11 +197,11 @@ fn tokenize_uint<'cx, C: Context<'cx>>(
     cx: &mut C,
     value: &Handle<JsValue>,
 ) -> Result<[u8; 32], Throw> {
-    let str = if value.is_a::<JsNumber>() {
-        let arg = value.downcast_or_throw::<JsNumber, _>(cx)?.value();
+    let str = if value.is_a::<JsNumber, _>(cx) {
+        let arg = value.downcast_or_throw::<JsNumber, _>(cx)?.value(cx);
         arg.to_string()
     } else {
-        value.downcast_or_throw::<JsString,_>(cx)?.value()
+        value.downcast_or_throw::<JsString, _>(cx)?.value(cx)
     };
     LenientTokenizer::tokenize_uint(&str).or_throw(cx)
 }
@@ -194,11 +210,11 @@ fn tokenize_int<'cx, C: Context<'cx>>(
     cx: &mut C,
     value: &Handle<JsValue>,
 ) -> Result<[u8; 32], Throw> {
-    let str = if value.is_a::<JsNumber>() {
-        let arg = value.downcast_or_throw::<JsNumber, _>(cx)?.value();
+    let str = if value.is_a::<JsNumber, _>(cx) {
+        let arg = value.downcast_or_throw::<JsNumber, _>(cx)?.value(cx);
         arg.to_string()
     } else {
-        value.downcast_or_throw::<JsString, _>(cx)?.value()
+        value.downcast_or_throw::<JsString, _>(cx)?.value(cx)
     };
     LenientTokenizer::tokenize_int(&str).or_throw(cx)
 }
@@ -208,7 +224,10 @@ fn tokenize_array<'cx, C: Context<'cx>>(
     value: &Handle<JsValue>,
     param: &ParamType,
 ) -> Result<Vec<Token>, Throw> {
-    let arr = value.downcast_or_throw::<JsArray,_>(cx)?.to_vec(cx).or_throw(cx)?;
+    let arr = value
+        .downcast_or_throw::<JsArray, _>(cx)?
+        .to_vec(cx)
+        .or_throw(cx)?;
     let mut result = vec![];
     for (_i, v) in arr.iter().enumerate() {
         let token = tokenize(cx, param, v)?;
@@ -225,8 +244,11 @@ fn tokenize_struct<'cx, C: Context<'cx>>(
     let mut params = param.iter();
     let mut result = vec![];
     // If it's an array we assume it is in the correct order
-    if value.is_a::<JsArray>() {
-        let arr = value.downcast_or_throw::<JsArray, _>(cx)?.to_vec(cx).or_throw(cx)?;
+    if value.is_a::<JsArray, _>(cx) {
+        let arr = value
+            .downcast_or_throw::<JsArray, _>(cx)?
+            .to_vec(cx)
+            .or_throw(cx)?;
         for (_i, v) in arr.iter().enumerate() {
             let p = params.next().ok_or(Error::InvalidData).or_throw(cx)?;
             let token = tokenize(cx, p, v)?;
@@ -257,4 +279,12 @@ fn tokenize<'cx, C: Context<'cx>>(
     }
 }
 
-register_module!(mut cx, { cx.export_class::<JsCoder>("Coder") });
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
+    cx.export_function("coderNew", Coder::js_new)?;
+    cx.export_function("coderEncodeInput", Coder::js_encode_input)?;
+    cx.export_function("coderDecodeInput", Coder::js_decode_input)?;
+    cx.export_function("coderDecodeOutput", Coder::js_decode_output)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Basically the whole API changed.

I used https://github.com/neon-bindings/examples/tree/223ba9b4870fefc18ad18a7a474f49acbe8b77f6/examples/async-sqlite as a guide to migrate the code.

Have reproduced this error locally:
```
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
node:internal/modules/cjs/loader:1310
  return process.dlopen(module, path.toNamespacedPath(filename));
                 ^

Error: dlopen(/Users/davidwalsh/code/0x-api/node_modules/@0x/fast-abi/bin/index.node, 0x0001): symbol not found in flat namespace '__ZN2v816FunctionTemplate3NewEPNS_7IsolateEPFvRKNS_20FunctionCallbackInfoINS_5ValueEEEENS_5LocalIS4_EENSA_INS_9SignatureEEEiNS_19ConstructorBehaviorENS_14SideEffectTypeEPKNS_9CFunctionE'
    at Module._extensions..node (node:internal/modules/cjs/loader:1310:18)
    at Module.load (node:internal/modules/cjs/loader:1089:32)
    at Module._load (node:internal/modules/cjs/loader:930:12)
    at Module.require (node:internal/modules/cjs/loader:1113:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/Users/davidwalsh/code/0x-api/node_modules/@0x/fast-abi/lib/fast_abi.js:5:19)
    at Module._compile (node:internal/modules/cjs/loader:1226:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1280:10)
    at Module.load (node:internal/modules/cjs/loader:1089:32)
    at Module._load (node:internal/modules/cjs/loader:930:12) {
  code: 'ERR_DLOPEN_FAILED'
}
```

Then have built a new binary from the source code in this PR, used that binary instead, and verified it functions.

# TODO
We really should add a test or two to this if we're going to keep maintaining it.