### PR TITLE
Update github actions versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,20 +11,22 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [19.x, 18.x, 16.x, 14.x]
+                node-version: [19.x, 18.x, 16.x]
                 os: [ubuntu-latest, macos-latest]
 
         runs-on: ${{ matrix.os }}
 
         steps:
             - name: Checkout the repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+
             - name: Set up Rust
               uses: actions-rs/toolchain@v1
               with:
                   toolchain: stable
+
             - name: Set up Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Updates legacy github actions and drops CI for node 14.x