### PR TITLE
Add support for node 20 & 21; Drop 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [19.x, 18.x, 16.x]
+                node-version: [21.x, 20.x, 19.x, 18.x]
                 os: [ubuntu-latest, macos-latest]
 
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Update github action publish workflow to publish binaries for Node 21 (Active) and Node 20 (Current). Drop support for Node 16 (Maintenance)

![image](https://github.com/0xProject/fast-abi/assets/5778036/c9ee0f99-e1df-4c26-b2d7-5548406268d0)
