### PR TITLE
[ci] Add Node 22, drop 21, 19 & 18

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,10 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [21.x, 20.x, 19.x, 18.x]
-                os: [ubuntu-latest, macos-latest]
+                node-version: [22.x, 20.x]
+                # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+                # macos-13 runs on intel processors, macos-14 runs on apple silicon
+                os: [ubuntu-latest, macos-13, macos-14]
 
         runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Update the publish workflow:
- Add Node 22.x, remove 21.x, 19.x and 18.x
- Remove `os` `macos-latest` and replace with `macos-13` & `macos-14`. `macos-13` runs on intel and `macos-14` runs on M1. Hopefully this will get us binaries for intel and apple chips and I won't have to build it on my computer.